### PR TITLE
remove quotes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,11 +61,11 @@ runs:
         fi
 
         if [[ -n $git_commit ]]; then
-            extra_options="${extra_options} --git_commit \"${git_commit}\""
+            extra_options="${extra_options} --git_commit ${git_commit}"
         fi
 
         if [[ -n $git_branch ]]; then
-            extra_options="${extra_options} --git_branch \"${git_branch}\""
+            extra_options="${extra_options} --git_branch ${git_branch}"
         fi
 
         if [[ $verbose == "true" ]]; then


### PR DESCRIPTION
The quotation marks added in the action around the git sea and branch were being uploaded to Waldo causing the waldo dashboard to not be able to tie commits and branches to the linked repo.

Example:
<img width="398" alt="Screenshot 2023-03-14 at 10 54 25 PM" src="https://user-images.githubusercontent.com/8712299/225193181-9f3658fc-e8c5-401d-b98d-c22d43e08a42.png">

Removing the quotes allows the Waldo dashboard to tie the items together properly:
<img width="398" alt="Screenshot 2023-03-14 at 10 55 23 PM" src="https://user-images.githubusercontent.com/8712299/225193336-f4caee18-9faf-41b6-99af-49b4c98f3cf2.png">

Note: branch provided in the screenshots is fake, which is why its not found, but the commit is real and demonstrates the fix